### PR TITLE
update starter_data.rake to use regexp

### DIFF
--- a/lib/tasks/starter_data.rake
+++ b/lib/tasks/starter_data.rake
@@ -7,7 +7,6 @@ class StarterDataGenerator
     @tag_dictionary = ["스타트업", "DBMS", "자바", "자바스크립트", "루비", "파이썬", "오픈소스", "C", "iOS", "안드로이드", "UX/UI",
      "하드웨어", "IoT", "web", "기계학습", "마케팅", "게임", "보안", "비트코인", "채용", "투자", "PHP", "SQL", "리눅스",
       "디자인", "빅데이터", "DB", "SQL", "마이크로소프트", "사업", "규제", "메이커", "다음카카오", "앱", "애널리틱스", "창업"]
-    @particles = ["을", "를", "이", "가", "은", "는", "의", "들", "\"", "에"]
   end
 
   def generate(feed_url: feed_url)
@@ -22,12 +21,7 @@ class StarterDataGenerator
   end
 
   def extract_tag_names(entry)
-    tag_names = []
-    if entry.content.present?
-      tag_names = clean_tag_names(entry.content)
-    else
-      tag_names = clean_tag_names(entry.summary)
-    end
+    tag_names = clean_tag_names(entry.content.present? ? entry.content : entry.summary)
 
     db_tag_names = []
     tag_names.each do |tag_name|
@@ -38,11 +32,11 @@ class StarterDataGenerator
   end
 
   def clean_tag_names(text)
-    text = text.gsub(Regexp.union(@particles),' ')
-    tag_names = text.split(" ") & @tag_dictionary
-    uniq_tag_names = tag_names.uniq
-    uniq_tag_names = ["기타"] if uniq_tag_names.empty?
-    uniq_tag_names
+    regexp_str = "(^|\s)(#{@tag_dictionary.join('|')})(\S{0,3})"
+    tag_names = text.scan(/#{regexp_str}/).collect { |el| el[1] }
+
+    tag_names.uniq!
+    tag_names.empty? ? ["기타"] : tag_names
   end
 
   

--- a/lib/tasks/starter_data.rake
+++ b/lib/tasks/starter_data.rake
@@ -38,8 +38,6 @@ class StarterDataGenerator
     tag_names.uniq!
     tag_names.empty? ? ["기타"] : tag_names
   end
-
-  
 end
 
 namespace :starter_data do


### PR DESCRIPTION
update starter_data.rake
Detail description is here.

Refactoring some code.
find tag feature is upated to use regexp. Now, it can detect keyword although it have prefix, like "안드로이드에서는"
