### PR TITLE
Fix structure.sql load fail in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ MAINTAINER seapy(iamseapy@gmail.com)
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --force-yes libpq-dev
+    apt-get install -y --force-yes libpq-dev postgresql-client
+
 
 # libcurl
 RUN apt-get install -y libcurl3 libcurl3-gnutls libcurl4-openssl-dev

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ in a `config/initializers/production.rb` or similar file:
 #### Docker
 
 ```
-$ docker build -t sapzil/test .
+$ docker build -t sapzil/sapzil .
 $ docker run -it --rm \
     -p 80:80 \
     -e SECRET_KEY_BASE=secretkey \
     -e DATABASE_URL=postgres://postgres:@192.168.59.103/sn_production \
-    sapzil/test
+    sapzil/sapzil
 ```


### PR DESCRIPTION
fixed by install postgresql-client. because structure load use `psql` command
and modify docker image name sapzil/test to sapzil/sapzil
