### PR TITLE
SSL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,4 @@ RUN ln -sf /dev/stderr /var/log/nginx/error.log
 
 #(required) nginx port number
 EXPOSE 80
+EXPOSE 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ADD Gemfile.lock /app/Gemfile.lock
 RUN bundle install --without development test
 ADD . /app
 
+# nginx config
+ADD config/nginx.conf /etc/nginx/sites-enabled/default
+
 # nginx log stdout
 RUN ln -sf /dev/stdout /var/log/nginx/access.log
 RUN ln -sf /dev/stderr /var/log/nginx/error.log

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ $ docker run -it --rm \
     -e MANDRILL_USERNAME= \
     -e MANDRILL_APIKEY= \
     -e GENERATOR_EMAIL= \
+    -v /somewhere/ssl.crt:/app/config/ssl/ssl.crt \
+    -v /somewhere/ssl.key:/app/config/ssl/ssl.key \
     sapzil/sapzil
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ $ docker run -it --rm \
     -e GENERATOR_EMAIL= \
     -v /somewhere/ssl.crt:/app/config/ssl/ssl.crt \
     -v /somewhere/ssl.key:/app/config/ssl/ssl.key \
+    -v /somewhere/ca.pem:/app/config/ssl/ca.pem \
     sapzil/sapzil
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ $ docker build -t sapzil/sapzil .
 ```
 $ docker run -it --rm \
     -p 80:80 \
+    -p 443:443 \
     -e SECRET_KEY_BASE=secretkey \
     -e DATABASE_URL=postgres://postgres:@192.168.59.103/sn_production \
+    -e SAPZIL_DOMAIN=sapzil.co \
+    -e SAPZIL_NAME=Sapzil \ 
     -e MANDRILL_USERNAME= \
     -e MANDRILL_APIKEY= \
     -e GENERATOR_EMAIL= \

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,7 +66,7 @@ class << Rails.application
   # whether absolute URLs should include https (does not require that
   # config.force_ssl be on)
   def ssl?
-    false
+    true
   end
 end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Lobsters::Application.configure do
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = false
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -16,6 +16,15 @@ server {
 
   ssl_certificate /app/config/ssl/ssl.crt;
   ssl_certificate_key /app/config/ssl/ssl.key;
+  ssl_trusted_certificate /app/config/ssl/ca.pem;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers 'kEECDH+ECDSA+AES128 kEECDH+ECDSA+AES256 kEECDH+AES128 kEECDH+AES256 kEDH+AES128 kEDH+AES256 DES-CBC3-SHA +SHA !aNULL !eNULL !LOW !kECDH !DSS !MD5 !EXP !PSK !SRP !CAMELLIA !SEED';
+  ssl_stapling on;
+  ssl_session_cache builtin:1000 shared:SSL:10m;
+  # Ref: HTTPS on Nginx: From Zero to A+ (Part 2) - Configuration, Ciphersuites, and Performance
+  #        https://juliansimioni.com/blog/https-on-nginx-from-zero-to-a-plus-part-2-configuration-ciphersuites-and-performance/
 
   location @unicorn_server {
     proxy_set_header Host $http_host;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,40 @@
+upstream unicorn_server {
+  server unix:/tmp/unicorn.sock fail_timeout=0;
+}
+
+server {
+  listen 80;
+
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+
+  root /app/public;
+  try_files $uri @unicorn_server;
+
+  ssl_certificate /app/config/ssl/ssl.crt;
+  ssl_certificate_key /app/config/ssl/ssl.key;
+
+  location @unicorn_server {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_redirect off;
+    proxy_pass http://unicorn_server;
+  }
+
+  location ~ ^/(assets|images|javascripts|stylesheets|swfs|system)/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+    add_header Last-Modified "";
+    add_header ETag "";
+
+    open_file_cache max=1000 inactive=500s;
+    open_file_cache_valid 600s;
+    open_file_cache_errors on;
+    break;
+  }
+}


### PR DESCRIPTION
reslove #19 
- ssl.crt, ssl.key is needed. file located `/home/ubuntu/deploy/ssl`
- all of http://sapzil.co traffic redirect to https://sapzil.co
- SSL Server secure test result A+ : https://www.ssllabs.com/ssltest/analyze.html?d=sapzil.co
